### PR TITLE
Fixed C4 bug

### DIFF
--- a/gamemodes/irresistible/cnr/features/c4.pwn
+++ b/gamemodes/irresistible/cnr/features/c4.pwn
@@ -366,6 +366,6 @@ stock SetPlayerC4Amount( playerid, amount ) {
 
 stock GivePlayerC4( playerid, amount )
 {
-    mysql_single_query( sprintf( "UPDATE `USERS` SET `C4` = %d WHERE `ID` = %d", p_C4Amount[ playerid ], GetPlayerAccountID( playerid ) ) );
+    mysql_single_query( sprintf( "UPDATE `USERS` SET `C4` = %d WHERE `ID` = %d", GetPlayerC4Amount( playerid ) + amount, GetPlayerAccountID( playerid ) ) );
     SetPlayerC4Amount( playerid, GetPlayerC4Amount( playerid ) + amount );
 }


### PR DESCRIPTION
- Once you buy x amount of c4 it wouldn't properly populate database, like for example if you bought 1, it would still display it as 0 database, but would be 1 in your items, this causes bug where you would use all your c4 and after relog, you would end up having 1 c4 still in your inventory